### PR TITLE
Update cv to ~.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0",
     "require": {
         "php": ">=7.1.3",
-        "civicrm/cv": "~0.2",
+        "civicrm/cv": "~0.3",
         "symfony/console": "~2.8|^3|^4",
         "symfony/process": "~2.8|^3|^4",
         "symfony/templating": "~2.8|^3|^4",


### PR DESCRIPTION
cv version .2 doesn't work with php 7.4 is the main thing, but also why not.

e.g. https://civicrm.stackexchange.com/questions/38061/getting-error-when-using-civix-generatemodule-or-civix-generateentity-curly-br